### PR TITLE
Add GitHub Actions CI workflow for Pico firmware build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,18 @@ jobs:
         export PICO_SDK_PATH=$HOME/pico-sdk
         mkdir build
         cd build
-        # Note: Point this to your actual source code directory pico/Pico-firmware
-        cmake ../pico/Pico-firmware -DCMAKE_BUILD_TYPE=Release -G Ninja
+        
+        # Utilize Linux 'find' command to auto-detect the exact path of the firmware directory
+        SRC_DIR=$(find "${{ github.workspace }}" -type d -iname "Pico-firmware" | head -n 1)
+        
+        # Fusing mechanism: Abort if the directory is completely missing
+        if [ -z "$SRC_DIR" ]; then
+          echo "FATAL ERROR: Could not find 'Pico-firmware' directory in the repository."
+          exit 1
+        fi
+        
+        echo "Auto-detected CMake source directory: $SRC_DIR"
+        cmake "$SRC_DIR" -DCMAKE_BUILD_TYPE=Release -G Ninja
 
     - name: 5. Execute full compilation
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: Pico Firmware CI
+
+# Trigger events: Triggers on pushes to the main or refactor-structure branches, or when a PR is opened
+on:
+  push:
+    branches: [ "main", "refactor-structure" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Utilize GitHub's free Linux runner
+
+    steps:
+    - name: 1. Checkout repository code
+      uses: actions/checkout@v4
+      with:
+        submodules: true # Extremely important if git submodules are used in the project
+
+    - name: 2. Install ARM cross-compiler and CMake
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential cmake ninja-build
+
+    - name: 3. Download and configure official Pico SDK
+      env:
+        PICO_SDK_URL: https://github.com/raspberrypi/pico-sdk.git
+      run: |
+        git clone --depth 1 $PICO_SDK_URL $HOME/pico-sdk
+        cd $HOME/pico-sdk
+        git submodule update --init
+
+    - name: 4. Execute CMake environment configuration
+      env:
+        PICO_SDK_PATH: ${{ github.workspace }}/../pico-sdk # Explicitly declare the physical path of the SDK for CMake
+      run: |
+        export PICO_SDK_PATH=$HOME/pico-sdk
+        mkdir build
+        cd build
+        # Note: Point this to your actual source code directory pico/Pico-firmware
+        cmake ../pico/Pico-firmware -DCMAKE_BUILD_TYPE=Release -G Ninja
+
+    - name: 5. Execute full compilation
+      run: |
+        cd build
+        ninja

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "main", "refactor-structure" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "refactor-structure" ]
 
 jobs:
   build:
@@ -39,6 +39,7 @@ jobs:
         cd build
         
         # Utilize Linux 'find' command to auto-detect the exact path of the firmware directory
+        # This solves path mismatch issues between Windows and Linux environments
         SRC_DIR=$(find "${{ github.workspace }}" -type d -iname "Pico-firmware" | head -n 1)
         
         # Fusing mechanism: Abort if the directory is completely missing


### PR DESCRIPTION
This commit introduces a custom GitHub Actions workflow to automate the Continuous Integration (CI) process for the project. 

Key configurations included:
- Sets up an Ubuntu runner environment.
- Installs the required ARM cross-compilation toolchain (gcc-arm-none-eabi) and build tools (CMake, Ninja).
- Automatically fetches and initializes the official Raspberry Pi Pico SDK.
- Executes the CMake configuration and Ninja build for the Pico-firmware directory.

This ensures that all incoming pushes and Pull Requests are automatically verified for compilation and syntax errors, significantly improving code reliability before merging.